### PR TITLE
Keep Msg constructors private

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ A customisble Datepicker written in Elm.
 
 Initialise the DatePicker by calling `DatePicker.initCalendar`. Provide it with a single argument: `Single` if you just want to be able to select a single date, or `Range` if you want to select a range.
 
-It's a good idea here to set up a Msg type that you can use to communicate with the DatePicker module.
-``` Elm
+It's a good idea here to set up a Msg type that you can use to forward DatePicker messages the DatePicker update function.
+
+```Elm
 type alias Model =
     { calendar : DatePicker.DatePicker }
 
@@ -19,7 +20,7 @@ type Msg
 init : ( Model, Cmd Msg )
 init =
     ( { calendar = DatePicker.initCalendar DatePicker.Single }
-    , Cmd.map DatePickerMsg (Task.perform DatePicker.ReceiveDate Date.now)
+    , Cmd.map DatePickerMsg DatePicker.receiveDate
     )
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -27,13 +28,14 @@ update msg model =
     case msg of
         ...
         DatePickerMsg datePickerMsg ->
-            { model | calendar = DatePicker.update datePickerMsg model.calendar } ! [  ]
+            { model | calendar = DatePicker.update datePickerMsg model.calendar } ! []
 ```
 
 To display the DatePicker, call `DatePicker.showCalendar`. This takes the initialised datepicker as its first argument, the month you want to display as the second, and a configuration record as the third.
 
 Don't forget, the Html will return a `DatePicker.Msg`, so you have to map it to the `DatePickerMsg Msg` we set up above, using `Html.map DatePickerMsg`.
-``` Elm
+
+```Elm
 view : Model -> Html Msg
 view model =
   div []
@@ -71,7 +73,9 @@ validDate date currentDate =
 ```
 
 ## Examples
+
 To run the examples:
+
 ```sh
   elm make examples/Main.elm --output=examples/examples.js
   elm-reactor

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.1",
+    "version": "2.0.0",
     "summary": "A customisable date picker written in Elm",
     "repository": "https://github.com/dwyl/elm-datepicker.git",
     "license": "BSD3",

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -28,7 +28,7 @@ main =
 init : ( Model, Cmd Msg )
 init =
     ( { calendar = DatePicker.initCalendar DatePicker.Single }
-    , Cmd.map DatePickerMsg (Task.perform DatePicker.ReceiveDate Date.now)
+    , Cmd.map DatePickerMsg DatePicker.receiveDate
     )
 
 

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -1,7 +1,7 @@
 module DatePicker
     exposing
         ( DatePicker
-        , Msg(..)
+        , Msg
         , Config
         , initCalendar
         , showCalendar
@@ -13,6 +13,12 @@ module DatePicker
         , isOpen
         , getMonth
         , getNextMonth
+        , clearDates
+        , toggleCalendar
+        , cancelDates
+        , previousMonth
+        , nextMonth
+        , receiveDate
         )
 
 {-| A customisable DatePicker that easily allows you to select a range of dates
@@ -26,6 +32,13 @@ These functions allow you to access data from the DatePicker model.
 
 @docs getFrom, getTo, getMonth, getNextMonth, isOpen
 
+
+# API Functions
+
+These functions allow us to perform updates to the datepicker model
+
+@docs clearDates, toggleCalendar, cancelDates, previousMonth, nextMonth, receiveDate
+
 -}
 
 import Html.Events exposing (onClick, onInput, onMouseOver)
@@ -33,6 +46,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import DateCore exposing (..)
 import Date exposing (..)
+import Task
 
 
 type alias MonthData =
@@ -72,12 +86,7 @@ type DatePicker
     = DatePicker Model
 
 
-{-| DatePicker Messages. These messages can be called manually with the update function as follows:
-
-    goToNextMonth : DatePicker -> ( DatePicker, Cmd Msg )
-    goToNextMonth datepicker =
-        DatePicker.update NextMonth datepicker
-
+{-| Opaque DatePicker Msg type
 -}
 type Msg
     = ReceiveDate Date
@@ -487,3 +496,45 @@ getNextMonth (DatePicker model) =
 isOpen : DatePicker -> Bool
 isOpen (DatePicker model) =
     model.open
+
+
+{-| Clears all selected dates
+-}
+clearDates : DatePicker -> DatePicker
+clearDates =
+    update ClearDates
+
+
+{-| Closes or opens calendar
+-}
+toggleCalendar : DatePicker -> DatePicker
+toggleCalendar =
+    update ToggleCalendar
+
+
+{-| Clears all selected dates and closes calendar
+-}
+cancelDates : DatePicker -> DatePicker
+cancelDates =
+    update CancelDates
+
+
+{-| Sets current month to previous month, and next month to current month
+-}
+previousMonth : DatePicker -> DatePicker
+previousMonth =
+    update PreviousMonth
+
+
+{-| Sets current month to next month, and next month to next month + 1
+-}
+nextMonth : DatePicker -> DatePicker
+nextMonth =
+    update NextMonth
+
+
+{-| Gets current date to initialise the calendar
+-}
+receiveDate : Cmd Msg
+receiveDate =
+    Task.perform ReceiveDate Date.now


### PR DESCRIPTION
ref #9 
Stops exposing Msg constructors, and implements functions for interacting with the module.
This is a breaking change, so will be a new major version on release.