### PR TITLE
#28 Fixes safari formatting bug

### DIFF
--- a/src/DateCore.elm
+++ b/src/DateCore.elm
@@ -311,7 +311,15 @@ dateFromString s =
 
 formatDate : Int -> Int -> Int -> String
 formatDate year month day =
-    toString year ++ "-" ++ toString month ++ "-" ++ toString day
+    toString year ++ "-" ++ formatWithZero (toString month) ++ "-" ++ formatWithZero (toString day) ++ "T00:00:00"
+
+
+formatWithZero : String -> String
+formatWithZero date =
+    if String.length date == 1 then
+        "0" ++ date
+    else
+        date
 
 
 dateToSring : Date -> String

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -349,7 +349,7 @@ showCalendar (DatePicker model) monthData config =
             monthData
     in
         div [ class config.calendarClass ]
-            [ h1 [ class config.titleClass, id "title" ] [ text (toString year ++ " " ++ toString month) ]
+            [ h1 [ class config.titleClass, id "title" ] [ text (toString month ++ " " ++ toString year) ]
             , table []
                 [ thead []
                     [ tr []


### PR DESCRIPTION
#28 Fixes safari formatting bug so that dates are recognised and displayed correctly in Safari.

Also swaps the order of the month and year in the dropdown so it's month followed by year not year first.