### PR TITLE
WCAG 2.0 Compliance

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,6 +10,7 @@
         "DatePicker"
     ],
     "dependencies": {
+        "elm-community/html-extra": "2.2.0 <= v < 3.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -57,6 +57,7 @@ Or
 import Html.Events exposing (onClick, onInput, onMouseOver)
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events.Extra exposing (onEnter)
 import DateCore exposing (..)
 import Date exposing (..)
 import Task
@@ -347,7 +348,16 @@ showDate (DatePicker { currentDate, from, to, single, overDate }) config date =
         case date of
             Just _ ->
                 if config.validDate date currentDate then
-                    td [ class config.dayClass, classList [ ( config.validClass, not selected ), ( config.selectedClass, selected ), ( config.rangeClass, insideRange ), ( config.rangeHoverClass, insideRangeOver ) ], onClick (SelectDate date), onMouseOver (OverDate date) ] [ text <| DateCore.getFormattedDate date ]
+                    td
+                        [ class config.dayClass
+                        , classList [ ( config.validClass, not selected ), ( config.selectedClass, selected ), ( config.rangeClass, insideRange ), ( config.rangeHoverClass, insideRangeOver ) ]
+                        , onClick (SelectDate date)
+                        , onMouseOver (OverDate date)
+                        , tabindex 0
+                        , attribute "role" "button"
+                        , onEnter (SelectDate date)
+                        ]
+                        [ text <| DateCore.getFormattedDate date ]
                 else
                     td [ class (config.dayClass ++ " " ++ config.disabledClass) ] [ text <| DateCore.getFormattedDate date ]
 

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -354,7 +354,8 @@ showDate (DatePicker { currentDate, from, to, single, overDate }) config date =
                         , onClick (SelectDate date)
                         , onMouseOver (OverDate date)
                         , tabindex 0
-                        , attribute "role" "button"
+                        , attribute "role" "option"
+                        , attribute "aria-selected" <| toString selected
                         , onEnter (SelectDate date)
                         ]
                         [ text <| DateCore.getFormattedDate date ]
@@ -431,6 +432,9 @@ showCalendar (DatePicker model) monthData config =
 
         title =
             config.titleFormatter year month
+
+        multiselectable =
+            model.selectDate /= Only |> toString
     in
         div [ class config.calendarClass ]
             [ h1 [ class config.titleClass, id "title" ] [ text title ]
@@ -439,7 +443,11 @@ showCalendar (DatePicker model) monthData config =
                     [ tr []
                         (renderWeekdays config)
                     ]
-                , tbody [] (showMonth (DatePicker model) config dates)
+                , tbody
+                    [ attribute "role" "listbox"
+                    , attribute "aria-multiselectable" multiselectable
+                    ]
+                    (showMonth (DatePicker model) config dates)
                 ]
             ]
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "eeue56/elm-html-test": "5.2.0 <= v < 6.0.0",
         "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
+        "elm-community/html-extra": "2.2.0 <= v < 3.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },


### PR DESCRIPTION
Add keyboard support by enabling the `tabindex` attribute for focus and `ENTER` key to select values in the calendar. Use [ARIA](https://www.w3.org/TR/wai-aria-1.1/) tags to show which months that can be selected, which months are currently selected, and to indicate if it is possible to select multiple values (range vs. single).

These changes ensures that we comply with the following WCAG 2.0 guidelines

- [Guideline 2.1 Keyboard Accessible: Make all functionality available from a keyboard.](https://www.w3.org/TR/WCAG20/#keyboard-operation)
- [Guideline 4.1 Compatible: Maximize compatibility with current and future user agents, including assistive technologies.](https://www.w3.org/TR/WCAG20/#ensure-compat)

Note that this change adds a dependency to [Html.Extra](https://package.elm-lang.org/packages/elm-community/html-extra/latest/Html-Events-Extra) in order to use the [onEnter](https://package.elm-lang.org/packages/elm-community/html-extra/latest/Html-Events-Extra#onEnter) event.