### PR TITLE
Cypress 4

### DIFF
--- a/cypress/integration/test.js
+++ b/cypress/integration/test.js
@@ -102,12 +102,12 @@ describe("Testing Example App", function() {
 
 /* gets position of current day on calendar */
 function todaysPosition() {
-  var currentMonth = new Date(Date.now());
-  var today = currentMonth.getDate();
+  const currentMonth = new Date(Date.now());
+  const today = currentMonth.getDate();
 
   currentMonth.setDate(1);
-  var firstOfMonth = currentMonth.getDay();
-  var todaysIndex;
+  const firstOfMonth = currentMonth.getDay();
+  let todaysIndex;
 
   if (firstOfMonth > 0) {
     todaysIndex = today + (firstOfMonth - 1);
@@ -120,7 +120,7 @@ function todaysPosition() {
 }
 
 function getToday() {
-  var today = todaysPosition();
+  const today = todaysPosition();
   return cy.get(`tbody > :nth-child(${today[0]}) > :nth-child(${today[1]})`);
 }
 
@@ -134,7 +134,7 @@ function nextDayPosition(currentDay) {
 }
 
 function getNextDay(currentDay) {
-  var nextDay = nextDayPosition(currentDay);
+  const nextDay = nextDayPosition(currentDay);
 
   if (lastDay()) {
     return cy
@@ -149,7 +149,7 @@ function getNextDay(currentDay) {
 }
 
 function lastDay() {
-  var currentDate = new Date(Date.now());
+  const currentDate = new Date(Date.now());
 
   switch (currentDate.getMonth()) {
     case 1:

--- a/cypress/integration/test.js
+++ b/cypress/integration/test.js
@@ -71,7 +71,7 @@ describe("Testing Example App", function() {
     });
 
     it("should select valid day", function() {
-      getNextDay(todaysPosition())
+      getToday()
         .click()
         .invoke("attr", "aria-selected")
         .should("equal", "true");
@@ -101,7 +101,7 @@ describe("Testing Example App", function() {
 });
 
 /* gets position of current day on calendar */
-function todaysPosition() {
+function getToday() {
   const currentMonth = new Date();
   const today = currentMonth.getDate();
   const day = currentMonth.getDay();
@@ -110,57 +110,10 @@ function todaysPosition() {
   const firstOfMonth = currentMonth.getDay();
   const todaysIndex = today + (firstOfMonth === 0 ? 7 : firstOfMonth) - 1;
 
-  return [Math.ceil(todaysIndex / 7), day === 0 ? 7 : day];
-}
+  const xIndex = Math.ceil(todaysIndex / 7);
+  const yIndex = day === 0 ? 7 : day;
 
-function getToday() {
-  const today = todaysPosition();
-  return cy.get(`tbody > :nth-child(${today[0]}) > :nth-child(${today[1]})`);
-}
-
-/* Determines position of next day based on current day
-  and whether it's the last day of the week or month */
-function nextDayPosition(currentDay) {
-  if (todayIsLastDayOfMonth()) {
-    return [1, (currentDay[1] % 7) + 1]
-  }
-  const currentDayIsSunday = currentDay[1] === 7;
-
-  return [
-    todayIsLastDayOfMonth() ? 1 : (currentDayIsSunday ? currentDay[0] + 1 : currentDay[0]),
-    (currentDay[1] % 7) + 1
-  ];
-}
-
-function getNextDay(currentDay) {
-  const nextDay = nextDayPosition(currentDay);
-
-  if (todayIsLastDayOfMonth()) {
-    cy
-      .get("#next-month")
-      .click();
-  }
-
-  return cy.get(
-    `tbody > :nth-child(${nextDay[0]}) > :nth-child(${nextDay[1]})`
-  );
-}
-
-function todayIsLastDayOfMonth() {
-  const currentDate = new Date();
-  const today = currentDate.getDate();
-
-  switch (currentDate.getMonth()) {
-    case 1:
-      return today === 29 || today === 28;
-    case 3:
-    case 5:
-    case 8:
-    case 10:
-      return today === 30;
-    default:
-      return today === 31;
-  }
+  return cy.get(`tbody > :nth-child(${xIndex}) > :nth-child(${yIndex})`);
 }
 
 function getOverflowIndex(array, index) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/dwyl/elm-datepicker#readme",
   "devDependencies": {
-    "cypress": "^2.1.0",
+    "cypress": "^4.0.2",
     "elm-format": "0.8.2",
     "elm-test": "0.19.1-revision2"
   },


### PR DESCRIPTION
Upgrade Cypress to latest version (4.0.2). Fixes #38.

There was quite a bit of complexity in the Cypress tests for selecting the next day. I found this to be broken for Sundays, and while I made an attempt to fix it, it seems completely viable to remove most of the complexity.