### PR TITLE
Set display month

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Don't forget, the Html will return a `DatePicker.Msg`, so you have to map it to 
 view : Model -> Html Msg
 view model =
   div []
-    [ DatePicker.showCalendar model.calendar (DatePicker.getMonth model.calendar) config
+    [ DatePicker.showCalendar model.calendar config
         |> Html.map DatePickerMsg
     ]
 

--- a/examples/Dropdown.elm
+++ b/examples/Dropdown.elm
@@ -54,7 +54,8 @@ view model =
         , div
             [ classList [ ( "dn", not (DatePicker.isOpen model.calendar) ), ( "dib", DatePicker.isOpen model.calendar ) ], class "absolute top-3 left-0 bg-white w-100 ba b--moon-gray pt2 pb3 z-3" ]
             [ span [ class "pointer pa2 gray bn pointer", onClick PreviousMonth ] [ text "<" ]
-            , DatePicker.showCalendar model.calendar (DatePicker.getMonth model.calendar) config |> Html.map DatePickerMsg
+            , DatePicker.showCalendar model.calendar config
+                |> Html.map DatePickerMsg
             , span [ class "pointer pa2 gray bn pointer", onClick NextMonth ] [ text ">" ]
             ]
         ]

--- a/examples/Range.elm
+++ b/examples/Range.elm
@@ -40,7 +40,7 @@ view model =
     div []
         [ h2 [ class "helvetica m0" ] [ text "Range DatePicker" ]
         , button [ id "previous-month", class "bn pointer gray", onClick PreviousMonth ] [ text "<" ]
-        , DatePicker.showCalendar model.calendar (DatePicker.getMonth model.calendar) config
+        , DatePicker.showCalendar model.calendar config
             |> Html.map DatePickerMsg
         , button [ id "next-month", class "bn pointer gray", onClick NextMonth ] [ text ">" ]
         ]

--- a/examples/Simple.elm
+++ b/examples/Simple.elm
@@ -39,7 +39,7 @@ view model =
     div []
         [ h2 [ class "helvetica m0" ] [ text "Simple DatePicker" ]
         , button [ id "previous-month", class "bn pointer gray", onClick PreviousMonth ] [ text "<" ]
-        , DatePicker.showCalendar model.calendar (DatePicker.getMonth model.calendar) DatePicker.defaultConfig
+        , DatePicker.showCalendar model.calendar DatePicker.defaultConfig
             |> Html.map DatePickerMsg
         , button [ id "next-month", class "bn pointer gray", onClick NextMonth ] [ text ">" ]
         ]

--- a/examples/Styled.elm
+++ b/examples/Styled.elm
@@ -38,7 +38,7 @@ view : Model -> Html Msg
 view model =
     div []
         [ h2 [ class "helvetica ma4" ] [ text "Styled DatePicker" ]
-        , DatePicker.showCalendar model.calendar (DatePicker.getMonth model.calendar) config
+        , DatePicker.showCalendar model.calendar config
             |> Html.map DatePickerMsg
         ]
 

--- a/examples/TwoMonth.elm
+++ b/examples/TwoMonth.elm
@@ -37,12 +37,20 @@ init =
 
 view : Model -> Html Msg
 view model =
+    let
+        ( year, month ) =
+            DatePicker.getMonth model.calendar
+
+        nextMonth =
+            Date.fromCalendarDate year month 1
+                |> Date.add Date.Months 1
+    in
     div []
         [ h2 [ class "helvetica" ] [ text "Two Month DatePicker" ]
         , button [ id "previous-month", class "bn gray pointer", onClick PreviousMonth ] [ text "<" ]
-        , DatePicker.showCalendar model.calendar (DatePicker.getMonth model.calendar) config
+        , DatePicker.showCalendar model.calendar config
             |> Html.map DatePickerMsg
-        , DatePicker.showCalendar model.calendar (DatePicker.getNextMonth model.calendar) config
+        , DatePicker.showCalendarForMonth ( Date.year nextMonth, Date.month nextMonth ) model.calendar config
             |> Html.map DatePickerMsg
         , button [ id "next-month", class "bn gray pointer", onClick NextMonth ] [ text ">" ]
         ]

--- a/src/DateCore.elm
+++ b/src/DateCore.elm
@@ -27,8 +27,8 @@ isLeapYear year =
     ((modBy 4 year == 0) && (modBy 100 year /= 0)) || (modBy 400 year == 0)
 
 
-daysInMonth : Year -> Month -> Int
-daysInMonth year month =
+daysInMonth : ( Year, Month ) -> Int
+daysInMonth ( year, month ) =
     case month of
         Jan ->
             31
@@ -71,9 +71,9 @@ daysInMonth year month =
             31
 
 
-datesOfMonth : Year -> Month -> List Date
-datesOfMonth year month =
-    List.range 1 (daysInMonth year month)
+datesOfMonth : ( Year, Month ) -> List Date
+datesOfMonth ( year, month ) =
+    List.range 1 (daysInMonth ( year, month ))
         |> List.map (Date.fromCalendarDate year month)
 
 
@@ -103,14 +103,14 @@ getFormattedDate =
         >> Maybe.withDefault ""
 
 
-getYearAndMonthNext : Year -> Month -> ( Year, Month )
-getYearAndMonthNext year month =
-    addMonths 1 ( year, month )
+getYearAndMonthNext : ( Year, Month ) -> ( Year, Month )
+getYearAndMonthNext month =
+    addMonths 1 month
 
 
-getYearAndMonthPrevious : Year -> Month -> ( Year, Month )
-getYearAndMonthPrevious year month =
-    addMonths -1 ( year, month )
+getYearAndMonthPrevious : ( Year, Month ) -> ( Year, Month )
+getYearAndMonthPrevious month =
+    addMonths -1 month
 
 
 addMonths : Int -> ( Year, Month ) -> ( Year, Month )

--- a/tests/Test/API.elm
+++ b/tests/Test/API.elm
@@ -17,6 +17,7 @@ import DatePicker
         , nextMonth
         , previousMonth
         , setDate
+        , setDisplayMonth
         , toggleCalendar
         )
 import Expect
@@ -86,8 +87,11 @@ suite =
                     let
                         newCalendar =
                             nextMonth rangeCalendar
+
+                        ( newYear, newMonth, _ ) =
+                            getMonth newCalendar
                     in
-                    Expect.equal (getMonth newCalendar) ( 2018, Feb, [] )
+                    Expect.equal ( newYear, newMonth ) ( 2018, Feb )
             , test "nextMonth - getNextMonth" <|
                 \_ ->
                     let
@@ -196,6 +200,19 @@ suite =
                         , \c -> Expect.equal (dateCase getTo c) invalid
                         ]
                         newCalendar2
+            , test "setDisplayMonth should update calendar's year and month" <|
+                \_ ->
+                    let
+                        date =
+                            parseDate "2021-08-13"
+
+                        newCalendar =
+                            setDisplayMonth (Date.year date) (Date.month date) singleCalendar
+
+                        ( year, month, _ ) =
+                            getMonth newCalendar
+                    in
+                    Expect.equal ( year, month ) ( 2021, Aug )
             , test "clearDates" <|
                 \_ ->
                     let

--- a/tests/Test/API.elm
+++ b/tests/Test/API.elm
@@ -9,7 +9,6 @@ import DatePicker
         , clearDates
         , getFrom
         , getMonth
-        , getNextMonth
         , getSelectedDate
         , getTo
         , initCalendar
@@ -17,7 +16,7 @@ import DatePicker
         , nextMonth
         , previousMonth
         , setDate
-        , setDisplayMonth
+        , setMonth
         , toggleCalendar
         )
 import Expect
@@ -84,44 +83,10 @@ suite =
                     Expect.equal (isOpen newCalendar) True
             , test "nextMonth - getMonth" <|
                 \_ ->
-                    let
-                        newCalendar =
-                            nextMonth rangeCalendar
-
-                        ( newYear, newMonth, _ ) =
-                            getMonth newCalendar
-                    in
-                    Expect.equal ( newYear, newMonth ) ( 2018, Feb )
-            , test "nextMonth - getNextMonth" <|
-                \_ ->
-                    let
-                        newCalendar =
-                            nextMonth rangeCalendar
-
-                        ( _, newMonth, _ ) =
-                            getNextMonth newCalendar
-                    in
-                    Expect.equal newMonth Mar
+                    Expect.equal (rangeCalendar |> nextMonth |> getMonth) ( 2018, Feb )
             , test "previousMonth - getMonth" <|
                 \_ ->
-                    let
-                        newCalendar =
-                            previousMonth rangeCalendar
-
-                        ( newYear, newMonth, _ ) =
-                            getMonth newCalendar
-                    in
-                    Expect.equal ( newYear, newMonth ) ( 2017, Dec )
-            , test "previousMonth - getNextMonth" <|
-                \_ ->
-                    let
-                        newCalendar =
-                            previousMonth rangeCalendar
-
-                        ( _, newMonth, _ ) =
-                            getNextMonth newCalendar
-                    in
-                    Expect.equal newMonth Jan
+                    Expect.equal (rangeCalendar |> previousMonth |> getMonth) ( 2017, Dec )
             , test "clearDates" <|
                 \_ ->
                     let
@@ -206,11 +171,10 @@ suite =
                         date =
                             parseDate "2021-08-13"
 
-                        newCalendar =
-                            setDisplayMonth (Date.year date) (Date.month date) singleCalendar
-
-                        ( year, month, _ ) =
-                            getMonth newCalendar
+                        ( year, month ) =
+                            singleCalendar
+                                |> setMonth ( Date.year date, Date.month date )
+                                |> getMonth
                     in
                     Expect.equal ( year, month ) ( 2021, Aug )
             , test "clearDates" <|

--- a/tests/Test/Init.elm
+++ b/tests/Test/Init.elm
@@ -6,7 +6,6 @@ import DatePicker
         , Selection(..)
         , getFrom
         , getMonth
-        , getNextMonth
         , getTo
         , initCalendar
         , isOpen
@@ -31,7 +30,5 @@ suite =
         , test "Default isOpen" <|
             \_ -> Expect.equal (isOpen rangeCalendar) False
         , test "Default Month" <|
-            \_ -> Expect.equal (getMonth rangeCalendar) ( 2018, Jan, [] )
-        , test "Default nextMonth" <|
-            \_ -> Expect.equal (getNextMonth rangeCalendar) ( 2018, Feb, [] )
+            \_ -> Expect.equal (getMonth rangeCalendar) ( 2018, Jan )
         ]

--- a/tests/Test/View.elm
+++ b/tests/Test/View.elm
@@ -25,7 +25,7 @@ rangeCalendar =
 
 calendarHtml : Html Msg
 calendarHtml =
-    showCalendar rangeCalendar ( 2018, Jan, [] ) defaultConfig
+    showCalendar rangeCalendar defaultConfig
 
 
 customConfig : Config
@@ -82,12 +82,12 @@ customConfigWithFormatters =
 
 customCalendar : Html Msg
 customCalendar =
-    showCalendar rangeCalendar ( 2018, Jan, [] ) customConfig
+    showCalendar rangeCalendar customConfig
 
 
 customCalenderWithFormatters : Html Msg
 customCalenderWithFormatters =
-    showCalendar rangeCalendar ( 2018, Jan, [] ) customConfigWithFormatters
+    showCalendar rangeCalendar customConfigWithFormatters
 
 
 suite : Test

--- a/tests/Test/View.elm
+++ b/tests/Test/View.elm
@@ -58,8 +58,8 @@ customWeekdayFormatter _ day =
             "Søndag"
 
 
-customTitleFormatter : Int -> Month -> String
-customTitleFormatter year month =
+customTitleFormatter : ( Int, Month ) -> String
+customTitleFormatter ( year, month ) =
     let
         formattedMonth =
             case month of


### PR DESCRIPTION
This PR adds an API function (`setMonth`) which enables the user to implement a month/year picker, as well as other use cases where a manual update of the displayed month is required.

With this function available it felt very natural to refactor the use of MonthData (it has been removed). The API is a bit cleaner and more flexible this way. See `examples/TwoMonth.elm` for how this affects the current use case.

A few points for consideration:
- I refactored all uses of `Int -> Month` to `(Int, Month)`. This is a breaking change that makes it more clear what the `Int` is about. Since there are other breaking API changes this shouldn't be that big of a deal, but it's still an API change. If it seems unnecessary I'm happy to revert this on exposed functions.
- `setDate` now also calls `setMonth` (the new API function). Is there any possible use case for `setDate` where this is not wanted behaviour? If so I can revert that change.