### PR TITLE
Prepare for launch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) 2018-2021 dwyl. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/DateCore.elm
+++ b/src/DateCore.elm
@@ -1,6 +1,5 @@
 module DateCore exposing
-    ( Year
-    , datesOfMonth
+    ( datesOfMonth
     , equal
     , getFormattedDate
     , getYearAndMonthNext

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -36,7 +36,7 @@ Or
 -}
 
 import Date exposing (Date)
-import DateCore exposing (Year)
+import DateCore
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onMouseOver)
@@ -61,7 +61,7 @@ type Selection
 
 type alias Model =
     { currentDate : Maybe Date
-    , month : ( Year, Month, List (Maybe Date) )
+    , month : ( Int, Month, List (Maybe Date) )
     , open : Bool
     , selectDate : FromTo
     , from : Maybe Date
@@ -133,7 +133,7 @@ type alias Config =
     , titleClass : String
     , weekdayFormat : String
     , weekdayFormatter : String -> Weekday -> String
-    , titleFormatter : ( Year, Month ) -> String
+    , titleFormatter : ( Int, Month ) -> String
     , validDate : Maybe Date -> Maybe Date -> Bool
     }
 
@@ -216,7 +216,7 @@ defaultConfig =
     }
 
 
-defaultTitleFormatter : ( Year, Month ) -> String
+defaultTitleFormatter : ( Int, Month ) -> String
 defaultTitleFormatter ( year, month ) =
     DateCore.monthToString month ++ " " ++ String.fromInt year
 
@@ -315,7 +315,7 @@ showDate (DatePicker { currentDate, from, to, single, overDate }) config date =
     td attributes [ text <| DateCore.getFormattedDate date ]
 
 
-getDates : ( Year, Month ) -> List (Maybe Date)
+getDates : ( Int, Month ) -> List (Maybe Date)
 getDates month =
     let
         datesOfMonth =
@@ -372,12 +372,12 @@ showCalendar (DatePicker model) =
 
 {-| Show any month from the calendar
 -}
-showCalendarForMonth : ( Year, Month ) -> DatePicker -> Config -> Html Msg
+showCalendarForMonth : ( Int, Month ) -> DatePicker -> Config -> Html Msg
 showCalendarForMonth ( year, month ) =
     showCalendar_ ( year, month, getDates ( year, month ) )
 
 
-showCalendar_ : ( Year, Month, List (Maybe Date) ) -> DatePicker -> Config -> Html Msg
+showCalendar_ : ( Int, Month, List (Maybe Date) ) -> DatePicker -> Config -> Html Msg
 showCalendar_ monthData (DatePicker model) config =
     let
         ( year, month, dates ) =
@@ -526,7 +526,7 @@ getSelectedDate (DatePicker model) =
 
 {-| Get the current month
 -}
-getMonth : DatePicker -> ( Year, Month )
+getMonth : DatePicker -> ( Int, Month )
 getMonth (DatePicker model) =
     let
         ( year, month, _ ) =
@@ -594,7 +594,7 @@ setDate date =
 
 {-| Manually set the selected month
 -}
-setMonth : ( Year, Month ) -> DatePicker -> DatePicker
+setMonth : ( Int, Month ) -> DatePicker -> DatePicker
 setMonth ( year, month ) (DatePicker model) =
     DatePicker { model | month = ( year, month, getDates ( year, month ) ) }
 


### PR DESCRIPTION
I looked into publishing the module as-is from `master` and consider these changes appropriate:

#### Add LICENSE

This is required in order to run `elm publish`. I used the BSD-3-Clause text as indicated in `elm.json`.

#### Remove Year from the public DatePicker module.

Since `Year` is a type alias for `Int` I think it's best to keep it internal and not use it in the DatePicker module. The alternative is to expose `Year` from `DatePicker`, but over all I think it causes more confusion that way.